### PR TITLE
use php8.1, added setup readme

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           repository: "php/php-src"
           path: "php-src"
-          ref: "PHP-8.0"
+          ref: "PHP-8.1"
       - name: "Extract stubs"
         run: "./extractor/extract.php"
       - name: 'Get previous tag'

--- a/README.md
+++ b/README.md
@@ -2,3 +2,19 @@ PHP 8 stubs
 ====================
 
 The stubs are automatically extracted from [php-src](https://github.com/php/php-src/) and are relevant for analyzing codebases that use PHP 8 or later.
+
+## Local Setup
+
+from the project root use the following commands:
+
+```
+mkdir php-src/
+cd php-src/
+git clone https://github.com/php/php-src.git .
+git checkout PHP-8.1
+cd ..
+
+cd extractor/
+composer install
+php extract.php
+```

--- a/README.md
+++ b/README.md
@@ -16,5 +16,7 @@ cd ..
 
 cd extractor/
 composer install
-php extract.php
+cd ..
+
+php ./extractor/extract.php
 ```


### PR DESCRIPTION
refs https://github.com/phpstan/phpstan/issues/6213

I was not able to end-to-end test this with phpstan

since I am runnning into local errors

```
staabm@MBP-von-Markus extractor % php extract.php

In ParserAbstract.php line 315:
                                                                     
  Syntax error, unexpected T_STRING, expecting T_VARIABLE on line 7  
                                                                     

extract


staabm@MBP-von-Markus extractor % php -v
PHP 8.0.13 (cli) (built: Nov 28 2021 14:26:44) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.13, Copyright (c) Zend Technologies
    with Zend OPcache v8.0.13, Copyright (c), by Zend Technologies
```