### PR TITLE
fix: allow `callable` in `ReflectionFunction` constructor

### DIFF
--- a/stubs/ext/reflection/ReflectionFunction.php
+++ b/stubs/ext/reflection/ReflectionFunction.php
@@ -2,7 +2,7 @@
 
 class ReflectionFunction extends \ReflectionFunctionAbstract
 {
-    public function __construct(Closure|string $function)
+    public function __construct(callable|Closure|string $function)
     {
     }
     public function __toString() : string


### PR DESCRIPTION
Hi!

In this code sample, PHPStan yields an error, but I believe it shouldn't: https://phpstan.org/r/f76ae755-2b7f-486f-99e4-f2895c9f5514

I'm not sure this is the correct place to post this contribution (this repository seems to be auto-updated), please guide me if not!