### PR TITLE
composer: use classmap autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,6 @@
 	"description": "PHP stubs extracted from php-src",
 	"license": ["MIT", "PHP-3.01"],
 	"autoload": {
-		"files": ["Php8StubsMap.php"]
+		"classmap": ["Php8StubsMap.php"]
 	}
 }


### PR DESCRIPTION
fixes duplicated Php8StubsMap definition when analysing by PHPStan
project which depends on phpstan/php-8-stubs