### PR TITLE
Use "numeric-string" type for some MySQLi properties

### DIFF
--- a/stubs/ext/mysqli/mysqli_affected_rows.php
+++ b/stubs/ext/mysqli/mysqli_affected_rows.php
@@ -1,5 +1,6 @@
 <?php 
 
+/** @return int|numeric-string */
 function mysqli_affected_rows(\mysqli $mysql) : int|string
 {
 }

--- a/stubs/ext/mysqli/mysqli_num_rows.php
+++ b/stubs/ext/mysqli/mysqli_num_rows.php
@@ -1,5 +1,6 @@
 <?php 
 
+/** @return int|numeric-string */
 function mysqli_num_rows(\mysqli_result $result) : int|string
 {
 }

--- a/stubs/ext/mysqli/mysqli_stmt_affected_rows.php
+++ b/stubs/ext/mysqli/mysqli_stmt_affected_rows.php
@@ -1,5 +1,6 @@
 <?php 
 
+/** @return int|numeric-string */
 function mysqli_stmt_affected_rows(\mysqli_stmt $statement) : int|string
 {
 }

--- a/stubs/ext/mysqli/mysqli_stmt_num_rows.php
+++ b/stubs/ext/mysqli/mysqli_stmt_num_rows.php
@@ -1,6 +1,7 @@
 <?php 
 
 #endif
+/** @return int|numeric-string */
 function mysqli_stmt_num_rows(\mysqli_stmt $statement) : int|string
 {
 }


### PR DESCRIPTION
>If the number of rows is greater than PHP_INT_MAX, the number will be returned as a string.

* https://www.php.net/manual/en/mysqli-result.num-rows.php
* https://www.php.net/manual/en/mysqli-stmt.num-rows.php

>If the number of affected rows is greater than maximum PHP int value, the number of affected rows will be returned as a string value.

* https://www.php.net/manual/en/mysqli.affected-rows.php
* https://www.php.net/manual/en/mysqli-stmt.affected-rows.php