### PR TITLE
fix 113: Make ob_start callback argument nullable for 8.0 ≤ PHP < 8.4

### DIFF
--- a/stubs/ext/standard/ob_start.php
+++ b/stubs/ext/standard/ob_start.php
@@ -1,7 +1,7 @@
 <?php 
 
 /* main/output.c */
-/** @param callable $callback */
+/** @param callable|null $callback */
 #[\Until('8.4')]
 function ob_start($callback = null, int $chunk_size = 0, int $flags = PHP_OUTPUT_HANDLER_STDFLAGS): bool
 {


### PR DESCRIPTION
This makes the `ob_start` method's `$callback` argument accept null for 8.0 ≤ PHP < 8.4, as per https://github.com/phpstan/php-8-stubs/issues/113