### PR TITLE
Extract stubs from PHP 8.6

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -123,6 +123,7 @@ jobs:
           path: "php-src"
           # 8.6 has no branch of its own yet, it is still master
           ref: "master"
+          persist-credentials: false
       - name: "Update stubs"
         run: "./extractor/extract.php --update -- 8.5 8.6"
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -112,6 +112,20 @@ jobs:
       - name: "Update stubs"
         run: "./extractor/extract.php --update -- 8.4 8.5"
 
+      # ---
+
+      - name: "Delete checked out php-src repo"
+        run: "rm -rf php-src"
+      - name: "Checkout PHP 8.6"
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: "php/php-src"
+          path: "php-src"
+          # 8.6 has no branch of its own yet, it is still master
+          ref: "master"
+      - name: "Update stubs"
+        run: "./extractor/extract.php --update -- 8.5 8.6"
+
       # end repeat
 
       - name: 'Get previous tag'

--- a/extractor/extract.php
+++ b/extractor/extract.php
@@ -4,6 +4,7 @@
 use PhpParser\Comment;
 use PhpParser\Node;
 use PhpParser\ParserFactory;
+use PhpParser\PhpVersion;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
@@ -24,7 +25,9 @@ use Symfony\Component\Finder\Finder;
 require_once __DIR__ . '/vendor/autoload.php';
 
 $parserFactory = new ParserFactory();
-$parser = $parserFactory->createForHostVersion();
+// php-src master already uses syntax newer than the PHP running this script,
+// so the stubs are parsed with everything php-parser knows instead
+$parser = $parserFactory->createForVersion(PhpVersion::getNewestSupported());
 
 $command = new class(
 	$parser,


### PR DESCRIPTION
Adds a PHP 8.6 extraction step, and fixes what that step exposed in the extractor.

8.6 has no branch of its own in php-src yet, so the step checks out `master`. It reports
`PHP_VERSION "8.6.0-dev"` today.

## The extractor drops properties and enum cases

The class merge in `compareStatements()` collects `ClassMethod` and `ClassConst` from the old statements
and puts them back. `Property` and `EnumCase` are collected by neither, so they are lost whenever a class
carries them.

Untagged members go into `$oldStmts`, which only methods and constants are read back out of. Members that
already carry `#[\Since]` land in `$untouchedStmts` and survive, which is why this has stayed invisible.

Running 8.5 to 8.6 without the fix loses real members, all of which are unchanged in php-src `master`:

| stub | lost |
| --- | --- |
| `Uri/WhatWg/UrlValidationErrorType` | all 29 enum cases |
| `Uri/WhatWg/UrlValidationError` | 3 properties |
| `Uri/UriComparisonMode` | 2 enum cases |
| `Uri/WhatWg/InvalidUrlException` | `public readonly array $errors` |
| `Zend/NoDiscard` | `public readonly ?string $message` |
| `ext/curl/CurlSharePersistentHandle` | `public readonly array $options` |

The fix mirrors the constants path. A member missing from the old version gets `#[\Since]`, and members
keep their place above the methods.

## The diff after the fix

I ran the extraction locally against php-src `master` to see it before CI does:

* 71 new stub files
* 167 modified, of which 155 are additions only and 11 are pure reordering
* 1 file with a net deletion, `ext/spl/DirectoryIterator`, and that one is a PHPDoc reformat:
  `/** @return int|false */` becomes a block with `@tentative-return-type` and `@return (int | false)`.

Before the extractor fix the same run produced 7 files with net deletions. After it, none that lose a
member.

Checked afterwards: `UrlValidationErrorType` has the same 29 cases as `master`, and `NoDiscard` keeps its
property.

No stubs are committed here, since the workflow commits those itself on `main`.
