### PR TITLE
Keep the class body in its existing order when merging

### DIFF
--- a/extractor/extract.php
+++ b/extractor/extract.php
@@ -463,43 +463,91 @@ $command = new class(
 				}
 			}
 
-			$newStmtsToSet = $untouchedStmts;
+			// the class body keeps the order it already has. Rebuilding it by category moves
+			// every member that has aged out of the version window to the top of the class, which
+			// makes each update churn files that did not really change.
+			$untouchedIds = [];
+			foreach ($untouchedStmts as $stmt) {
+				$untouchedIds[spl_object_id($stmt)] = true;
+			}
+
+			$newMethodsByName = [];
 			foreach ($newMethods as $stmt) {
-				$methodName = $stmt->name->toLowerString();
-				if (!array_key_exists($methodName, $oldMethods)) {
-					$stmt->attrGroups[] = new Node\AttributeGroup([
-						new Node\Attribute(
-							new Node\Name\FullyQualified('Since'),
-							[new Node\Arg(new Node\Scalar\String_($updateTo))],
-						),
-					]);
+				$newMethodsByName[$stmt->name->toLowerString()] = $stmt;
+			}
+
+			$newConstantsByName = [];
+			foreach ($newConstants as $stmt) {
+				$namesKey = implode(',', array_map(static fn (Node\Const_ $const) => $const->name->toString(), $stmt->consts));
+				$newConstantsByName[$namesKey] = $stmt;
+			}
+
+			$newStmtsToSet = [];
+			$takenMethods = [];
+			$takenConstants = [];
+			foreach ($old->stmts as $stmt) {
+				if (array_key_exists(spl_object_id($stmt), $untouchedIds)) {
 					$newStmtsToSet[] = $stmt;
 					continue;
 				}
 
-				foreach ($this->compareFunctions($oldMethods[$methodName], $stmt, $updateTo) as $functionStmt) {
-					$newStmtsToSet[] = $functionStmt;
+				if ($stmt instanceof Node\Stmt\ClassMethod) {
+					$methodName = $stmt->name->toLowerString();
+					if (!array_key_exists($methodName, $newMethodsByName)) {
+						continue;
+					}
+
+					$takenMethods[$methodName] = true;
+					foreach ($this->compareFunctions($stmt, $newMethodsByName[$methodName], $updateTo) as $functionStmt) {
+						$newStmtsToSet[] = $functionStmt;
+					}
+
+					continue;
 				}
+
+				if ($stmt instanceof Node\Stmt\ClassConst) {
+					$namesKey = implode(',', array_map(static fn (Node\Const_ $const) => $const->name->toString(), $stmt->consts));
+					if (!array_key_exists($namesKey, $newConstantsByName)) {
+						continue;
+					}
+
+					$takenConstants[$namesKey] = true;
+					foreach ($this->compareConstants($stmt, $newConstantsByName[$namesKey], $updateTo) as $constantStmt) {
+						$newStmtsToSet[] = $constantStmt;
+					}
+				}
+			}
+
+			// whatever the new version adds goes after what is already there
+			foreach ($newMethods as $stmt) {
+				if (array_key_exists($stmt->name->toLowerString(), $takenMethods)) {
+					continue;
+				}
+
+				$stmt->attrGroups[] = new Node\AttributeGroup([
+					new Node\Attribute(
+						new Node\Name\FullyQualified('Since'),
+						[new Node\Arg(new Node\Scalar\String_($updateTo))],
+					),
+				]);
+				$newStmtsToSet[] = $stmt;
 			}
 
 			// todo has a method been removed?
 
 			foreach ($newConstants as $stmt) {
 				$namesKey = implode(',', array_map(static fn (Node\Const_ $const) => $const->name->toString(), $stmt->consts));
-				if (!array_key_exists($namesKey, $oldConstants)) {
-					$stmt->attrGroups[] = new Node\AttributeGroup([
-						new Node\Attribute(
-							new Node\Name\FullyQualified('Since'),
-							[new Node\Arg(new Node\Scalar\String_($updateTo))],
-						),
-					]);
-					$newStmtsToSet[] = $stmt;
+				if (array_key_exists($namesKey, $takenConstants)) {
 					continue;
 				}
 
-				foreach ($this->compareConstants($oldConstants[$namesKey], $stmt, $updateTo) as $constantStmt) {
-					$newStmtsToSet[] = $constantStmt;
-				}
+				$stmt->attrGroups[] = new Node\AttributeGroup([
+					new Node\Attribute(
+						new Node\Name\FullyQualified('Since'),
+						[new Node\Arg(new Node\Scalar\String_($updateTo))],
+					),
+				]);
+				$newStmtsToSet[] = $stmt;
 			}
 
 			// todo has a constant been removed?


### PR DESCRIPTION
The preparatory PR from phpstan/php-8-stubs#163. No 8.6 here, this only makes the order stable.

## Why members move

`compareStatements()` rebuilds a class body by category:

```php
$newStmtsToSet = $untouchedStmts;   // everything outside the current version window
foreach ($newMethods as $stmt) { ... }
foreach ($newConstants as $stmt) { ... }
```

`filterStatementsByVersion()` returns `[$oldStmts, $newStmts]` and the caller reads it as
`[$untouchedStmts, $oldStmts]`. So anything that has aged out of the window is written before every method,
wherever it used to sit.

Your `DateTime` example is exactly this. `__wakeup` carries `#[\Until('8.5')]`, so its `untilId` is 80499.
Coming from 8.4 that is not below 80400 and it stays put. Coming from 8.5 it is below 80500, it becomes
untouched, and it jumps to the top of the class.

That also means the churn grows at each step, because more members age out every version.

## The change

Walk the old body in its own order. Each member is replaced by its merged version in place, and whatever
the new version adds is appended after. Aged-out members keep their position instead of being hoisted.

## Effect

Measured on the 8.5 to 8.6 run, which is what #163 does:

| | files touched | pure reordering | additions only | net deletions |
| --- | --- | --- | --- | --- |
| today | 98 | 16 | 75 | 7 |
| with this | 82 | **0** | 75 | 7 |

The 16 reordering files are simply gone, and the other two columns are unchanged, so nothing else moved.
`DateTime.php`, `DateInterval.php` and `DatePeriod.php` are no longer touched at all.

The committed stubs were generated by the old order, so the first run after this reorders them once. That
is the one-time cost, and it is why this goes first.

No stubs are committed here, the workflow commits those on `main`.
